### PR TITLE
Download HD videos when available

### DIFF
--- a/tumblr-photo-video-ripper.py
+++ b/tumblr-photo-video-ripper.py
@@ -53,7 +53,14 @@ class DownloadWorker(Thread):
 
             if medium_type == "video":
                 video_player = post["video-player"][1]["#text"]
-                pattern = re.compile(r'[\S\s]*src="(\S*)" ')
+                hd_pattern = re.compile(r'.*"hdUrl":("([^\s,]*)"|false),')
+                hd_match = hd_pattern.match(video_player)
+                if hd_match is not None:
+                    try:
+                        return hd_match.group(2).replace('\\', '')
+                    except IndexError:
+                        pass
+                pattern = re.compile(r'.*src="(\S*)" ')
                 match = pattern.match(video_player)
                 if match is not None:
                     try:


### PR DESCRIPTION
Sometimes there are HD videos available however the crawler always downloads the default one (480). This change tries to match `hdUrl` in the text and uses that if possible.

Two possible `hdUrl` values:
* `"http:\\/\\/foo\\/bar"`
* `false`

The code will try to extract the first one and if it fails it will follow the old route.