### PR TITLE
[kyeolee89] : tumblr video download fix

### DIFF
--- a/tumblr-photo-video-ripper.py
+++ b/tumblr-photo-video-ripper.py
@@ -55,12 +55,12 @@ class DownloadWorker(Thread):
                 video_player = post["video-player"][1]["#text"]
                 hd_pattern = re.compile(r'.*"hdUrl":("([^\s,]*)"|false),')
                 hd_match = hd_pattern.match(video_player)
-                if hd_match is not None:
+                if hd_match.group(2) is not None:
                     try:
                         return hd_match.group(2).replace('\\', '')
                     except IndexError:
                         pass
-                pattern = re.compile(r'.*src="(\S*)" ')
+                pattern = re.compile(r'.*src="(\S*)"', re.DOTALL)
                 match = pattern.match(video_player)
                 if match is not None:
                     try:


### PR DESCRIPTION
Please check the sample site with "honorwings-blog". I think we should have "hd_match.group (2)" instead of "hd_match" on line 58. Check out the sample site and it will include a YouTube link. And the 63th line does not contain line breaks in the regular expression, so it is not processed. You must modify it to include line breaks with the "re.DOTALL" option. After that, we need to download various services such as YouTube and Vimeo. Please check PR.