### PR TITLE
Fix the issue when hd_match.group(1) == false while hd_match.group(2) is None

### DIFF
--- a/tumblr-photo-video-ripper.py
+++ b/tumblr-photo-video-ripper.py
@@ -55,11 +55,11 @@ class DownloadWorker(Thread):
                 video_player = post["video-player"][1]["#text"]
                 hd_pattern = re.compile(r'.*"hdUrl":("([^\s,]*)"|false),')
                 hd_match = hd_pattern.match(video_player)
-                if hd_match is not None:
-                    try:
+                try:
+                    if hd_match is not None and hd_match.group(1) != 'false':
                         return hd_match.group(2).replace('\\', '')
-                    except IndexError:
-                        pass
+                except IndexError:
+                    pass
                 pattern = re.compile(r'.*src="(\S*)" ')
                 match = pattern.match(video_player)
                 if match is not None:


### PR DESCRIPTION
So sorry for introducing the bug. The issue was, when `hdUrl` is set to `false`, `hd_match.group(2)` will still exist, but with the value `None`. In our old code, this will simply cause an exception and skip all the following logic for downloading a regular video. That means, the old code will only work for HD videos.

The fix first checks if `hdUrl` is `false`, if not, tries to download the HD video. Otherwise, still downloads the regular video.