### PR TITLE
docs: fix simple typo, differnet -> different

### DIFF
--- a/tumblr-photo-video-ripper.py
+++ b/tumblr-photo-video-ripper.py
@@ -77,7 +77,7 @@ class DownloadWorker(Thread):
         except TypeError:
             pass
 
-    # can register differnet regex match rules
+    # can register different regex match rules
     def _register_regex_match_rules(self):
         # will iterate all the rules
         # the first matched result will be returned


### PR DESCRIPTION
There is a small typo in tumblr-photo-video-ripper.py.

Should read `different` rather than `differnet`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md